### PR TITLE
Cosign fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.7.8] - 2023-11-16
+
+### Changed
+ - cosign version upgrade with alpine image; must include --insecure-ignore-tlog flag
+ - changed classpath folder in pom from /etc to /config
+ 
 ## [1.7.6] - 2023-10-30
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
+# Start with a base image containing Java runtime
 FROM eclipse-temurin:11-jre-alpine
 
 # Add Maintainer Info
 LABEL maintainer="gabriele.deluca@eng.it"
 
-RUN apk add --no-cache openssl curl
-
+# Create non-privileged user directory, and make it as workable directory
 RUN mkdir -p /home/nobody/app && mkdir -p /home/nobody/data/log/ucapp && mkdir -p /.sigstore
 RUN apk add --no-cache openssl curl cosign
 
@@ -16,9 +16,14 @@ COPY target/dependency-jars /home/nobody/app/dependency-jars
 # Add the application's jar to the container
 ADD target/dataUsage.jar /home/nobody/app/dataUsage.jar
 
+# Change ownership of non-privileged user directory and logs directories
 RUN chown -R nobody:nogroup /home/nobody && chown -R nobody:nogroup /.sigstore
 
+# Set non-privileged user to run commands
 USER 65534
 
+# Run the jar file 
 ENTRYPOINT java -jar /home/nobody/app/dataUsage.jar
+
+# Healthy Status
 HEALTHCHECK --interval=5s --retries=12 --timeout=10s CMD curl --fail -k https://localhost:8080/platoontec/PlatoonDataUsage/1.0/about/version || exit 1

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     ports:
       - "8180:8180"
     volumes:
-      - ./uc-dataapp_resources:/etc
+      - ./uc-dataapp_resources:/config
       - ./ecc_cert:/cert
       - uc_data:/data
  

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,8 @@
     <properties>
         <java.version>11</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <maven.minimum.version>3.3.9</maven.minimum.version>
         <springfox-version>3.0.0</springfox-version>
         <okhttp.version>4.2.2</okhttp.version>
-        <multipart.message.processor.version>1.0.17</multipart.message.processor.version>
         <swagger-annotations.version>1.5.20</swagger-annotations.version>
         <de.fraunhofer.iais.eis.ids.infomodel.validator.version>4.2.7</de.fraunhofer.iais.eis.ids.infomodel.validator.version>
         <de.fraunhofer.iais.eis.ids.infomodel.version>4.2.7</de.fraunhofer.iais.eis.ids.infomodel.version>
@@ -80,7 +78,7 @@
 							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 						</manifest>
 						<manifestEntries>
-							<Class-Path>. /etc/ </Class-Path>
+							<Class-Path>. /config/ </Class-Path>
 						</manifestEntries>
 					</archive>
 				</configuration>
@@ -109,18 +107,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
         </dependency>
-        <!--SpringFox dependencies -->
-   <!--     <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-oas</artifactId>
-            <version>${springfox-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger-ui</artifactId>
-            <version>${springfox-version}</version>
-        </dependency>
--->
         <dependency>
             <groupId>com.github.joschi.jackson</groupId>
             <artifactId>jackson-datatype-threetenbp</artifactId>
@@ -253,39 +239,29 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-        <!--  
-        -->
-
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20190722</version>
         </dependency>
-        
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>2.4.0</version>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp.version}</version>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
@@ -298,13 +274,11 @@
             <artifactId>java</artifactId>
             <version>${de.fraunhofer.iais.eis.ids.infomodel.version}</version>
         </dependency>
-
         <dependency>
             <groupId>de.fraunhofer.iais.eis.ids</groupId>
             <artifactId>infomodel-serializer</artifactId>
             <version>${de.fraunhofer.iais.eis.ids.infomodel.serializer.version}</version>
         </dependency>
-
         <dependency>
             <groupId>de.fraunhofer.iais.eis.ids.infomodel</groupId>
             <artifactId>validation-serialization-provider</artifactId>

--- a/src/main/java/com/tecnalia/datausage/config/CertificationCheck.java
+++ b/src/main/java/com/tecnalia/datausage/config/CertificationCheck.java
@@ -38,7 +38,7 @@ public class CertificationCheck {
 			String rootImageName = "rdlabengpa/ids_uc_data_app_platoon:v";
 			List<String> startCmdList = getStartCmdList();
 			List<String> cmdList = new ArrayList<String>(startCmdList);
-			cmdList.add("echo | cosign verify --key " + targetDirectory.resolve("trueconn.pub") + " " + rootImageName
+			cmdList.add("echo | cosign verify --insecure-ignore-tlog --key " + targetDirectory.resolve("trueconn.pub") + " " + rootImageName
 					+ buildProperties.getVersion());
 
 			String getCosignVerification = processExecutor.executeProcess(cmdList);


### PR DESCRIPTION
With new apline update, ne version of cosign is provided (2.0.1_r5) and that one requires additional no secure flag
Fixed mount point for property files from /etc to /config